### PR TITLE
fix import path for macros header

### DIFF
--- a/ios/bindings.mm
+++ b/ios/bindings.mm
@@ -1,7 +1,7 @@
 #include "bindings.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 #import <Security/Security.h>
-#import "macros.h"
+#import "../cpp/macros.h"
 
 
 namespace ops2 {


### PR DESCRIPTION
`macros.h` was not found by xcode build system, this PR changes the import to a relative path and this seems to fix the issue

<img width="696" alt="Screenshot 2023-11-28 at 16 16 21" src="https://github.com/OP-Engineering/op-s2/assets/4848554/ea127051-2e19-4047-818e-92dbae8aa63e">
