### PR TITLE
fix for nullable javaScriptContextHolder

### DIFF
--- a/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
+++ b/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
@@ -127,7 +127,7 @@ class OPS2Bridge(reactContext: ReactApplicationContext) {
   }
 
   fun install(context: ReactContext) {
-      val jsContextPointer = context.javaScriptContextHolder.get()
+      val jsContextPointer = context.javaScriptContextHolder!!.get()
 
       initialize(
           jsContextPointer,


### PR DESCRIPTION
On RN 0.73 [`javaScriptContextHolder` has been made nullable](https://github.com/facebook/react-native/blob/v0.73.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L542) and so the build step fails.

This PR fixes it by using the [not-null assertion operator](https://kotlinlang.org/docs/null-safety.html#the-operator)