### PR TITLE
fix: add consumer proguard rule

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,6 +70,8 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
 
+    consumerProguardFiles "consumer-rules.pro"
+
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all -DON_ANDROID"

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.op.s2.** { *; }


### PR DESCRIPTION
### Description

Added a ProGuard consumer rule to prevent app crashes when ProGuard is enabled. Without this fix, the app crashes immediately when ProGuard is enabled.

### Tests
Build an example app with ProGuard enabled and verify it opens without crashing.