### PR TITLE
Support RN 76

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -32,12 +32,23 @@ find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 find_library(LOG_LIB log)
 
-target_link_libraries(
-  ${PACKAGE_NAME}
-  ${LOG_LIB}
-  fbjni::fbjni
-  ReactAndroid::jsi
-  ReactAndroid::turbomodulejsijni
-  ReactAndroid::react_nativemodule_core
-  android
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ${LOG_LIB}
+    fbjni::fbjni
+    ReactAndroid::jsi
+    ReactAndroid::reactnative
+    android
+  )
+else()
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ${LOG_LIB}
+    fbjni::fbjni
+    ReactAndroid::jsi
+    ReactAndroid::turbomodulejsijni
+    ReactAndroid::react_nativemodule_core
+    android
+  )
+endif()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,6 +89,7 @@ android {
               "**/libreact_nativemodule_core.so",
               "**/libturbomodulejsijni.so",
               "**/libc++_shared.so",
+              "**/libreactnative.so",
               "**/libfbjni.so"
       ]
     }


### PR DESCRIPTION
- Use right dynamic library imports as per https://github.com/react-native-community/discussions-and-proposals/discussions/816
- Exclude libreactnative.so from being included as per https://github.com/mrousavy/react-native-vision-camera/pull/3281