### PR TITLE
feat: use ndkVersion from root project or op default

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ def reactNativeArchitectures() {
 android {
 
   namespace "com.op.s2"
-
+  ndkVersion getExtOrDefault("ndkVersion")
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   buildFeatures {


### PR DESCRIPTION
Without this fix, the library uses a version of NDK that may be incompatible.

This way, we ensure the use of the root project's NDK or the default defined in `gradle.properties`