### PR TITLE
Fix the iOS install method so get bridge correctly

### DIFF
--- a/ios/OPS2.mm
+++ b/ios/OPS2.mm
@@ -6,23 +6,21 @@
 #import <jsi/jsi.h>
 
 @implementation OPS2
+@synthesize bridge = _bridge;
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
-  RCTBridge *bridge = [RCTBridge currentBridge];
-  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
+  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)_bridge;
   if (cxxBridge == nil) {
     return @false;
   }
 
-  using namespace facebook;
-
-  auto jsiRuntime = (jsi::Runtime *)cxxBridge.runtime;
+  auto jsiRuntime = (facebook::jsi::Runtime *)cxxBridge.runtime;
   if (jsiRuntime == nil) {
     return @false;
   }
   auto &runtime = *jsiRuntime;
-  auto callInvoker = bridge.jsCallInvoker;
+  auto callInvoker = _bridge.jsCallInvoker;
 
   ops2::install(runtime, callInvoker);
 


### PR DESCRIPTION
`RCTBridge *bridge = [RCTBridge currentBridge]`; no longer works in React Native 0.85 (bridgeless). 

With the changes in the PR, it works again.