### PR TITLE
feat: expose biometric prompt customization + fix iOS accessibility enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,31 @@ const { error } = set({
   accessibility: ACCESSIBILITY.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY,
   // OR works for both iOS and Android
   withBiometrics: true,
+  // Optional — customize the biometric / device-credential prompt
+  biometricPrompt: {
+    title: 'Unlock to continue',
+    subtitle: 'Authenticate to access your data',
+    negativeButtonText: 'Cancel',
+    allowDeviceCredential: true,
+    allowBiometricWeak: false,
+  },
 });
 
 const { error, value } = get({
   key: 'myValue',
   withBiometrics: true,
+  biometricPrompt: {
+    title: 'Unlock to read',
+    allowDeviceCredential: true,
+  },
 });
 
 const { error } = del({
   key: 'myValue',
   withBiometrics: true,
+  biometricPrompt: {
+    title: 'Unlock to delete',
+  },
 });
 ```
 
@@ -71,6 +86,29 @@ On iOS you can specify an accessibility value which allows you to customize when
 ### With biometrics
 
 When using biometric info you need to include `NSFaceIDUsageDescription` in your info.plist, which will prompt the user for permission to use faceID.
+
+#### Customizing the prompt
+
+Pass a `biometricPrompt` object to `set` / `get` / `del` to customize the auth UI and choose which authenticators are accepted:
+
+| Field                   | Description                                                                                                                                                                                   | Default                 |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `title`                 | Prompt title                                                                                                                                                                                  | `"Please authenticate"` |
+| `subtitle`              | Prompt subtitle. iOS has no native subtitle slot so it is appended to the title.                                                                                                              | `""`                    |
+| `negativeButtonText`    | Label of the negative (cancel) button. Omitted on Android when `allowDeviceCredential: true` because the device-credential button takes that slot on API < 30.                                | `"Cancel"`              |
+| `allowDeviceCredential` | Allow the device passcode (PIN/pattern/password) as an alternative to biometrics. On iOS adds `kSecAccessControlDevicePasscode`; on Android OR's in `DEVICE_CREDENTIAL`.                      | `false`                 |
+| `allowBiometricWeak`    | Allow Class 2 (weak) biometrics. On iOS uses `kSecAccessControlBiometryAny` instead of `kSecAccessControlBiometryCurrentSet`; on Android uses `BIOMETRIC_WEAK` instead of `BIOMETRIC_STRONG`. | `false`                 |
+
+The resulting Android authenticator combinations are:
+
+| `allowDeviceCredential` | `allowBiometricWeak` | Android `BiometricManager.Authenticators` |
+| ----------------------- | -------------------- | ----------------------------------------- |
+| `false`                 | `false`              | `BIOMETRIC_STRONG`                        |
+| `true`                  | `false`              | `BIOMETRIC_STRONG \| DEVICE_CREDENTIAL`   |
+| `false`                 | `true`               | `BIOMETRIC_WEAK`                          |
+| `true`                  | `true`               | `BIOMETRIC_WEAK \| DEVICE_CREDENTIAL`     |
+
+If you pass `withBiometrics: true` without a `biometricPrompt` object at all, the prompt falls back to the defaults listed above.
 
 ## Secure Enclave
 

--- a/android/bindings.cpp
+++ b/android/bindings.cpp
@@ -6,14 +6,57 @@
 namespace ops2 {
 namespace jsi = facebook::jsi;
 
-std::function<void(const char *, const char *, bool)> _set;
-std::function<std::string(const char *, bool)> _get;
-std::function<void(const char *, bool)> _del;
+std::function<void(const char *, const char *, bool, BiometricPromptOptions)> _set;
+std::function<std::string(const char *, bool, BiometricPromptOptions)> _get;
+std::function<void(const char *, bool, BiometricPromptOptions)> _del;
 
-void install(jsi::Runtime &rt,
-             std::function<void(const char *, const char *, bool)> setFn,
-             std::function<std::string(const char *, bool)> getFn,
-             std::function<void(const char *, bool)> delFn) {
+static BiometricPromptOptions extractBiometricPromptOptions(jsi::Runtime &rt, const jsi::Object &params) {
+  BiometricPromptOptions options;
+  options.title = "Please authenticate";
+  options.subtitle = "";
+  options.negativeButtonText = "Cancel";
+  options.allowDeviceCredential = false;
+  options.allowBiometricWeak = false;
+
+  if (!params.hasProperty(rt, "biometricPrompt")) {
+    return options;
+  }
+
+  jsi::Value prop = params.getProperty(rt, "biometricPrompt");
+  if (prop.isNull() || prop.isUndefined() || !prop.isObject()) {
+    return options;
+  }
+
+  jsi::Object prompt = prop.asObject(rt);
+
+  auto getString = [&](const char *name, const std::string &fallback) -> std::string {
+    if (!prompt.hasProperty(rt, name)) return fallback;
+    jsi::Value v = prompt.getProperty(rt, name);
+    if (!v.isString()) return fallback;
+    return v.asString(rt).utf8(rt);
+  };
+
+  auto getBool = [&](const char *name, bool fallback) -> bool {
+    if (!prompt.hasProperty(rt, name)) return fallback;
+    jsi::Value v = prompt.getProperty(rt, name);
+    if (!v.isBool()) return fallback;
+    return v.getBool();
+  };
+
+  options.title = getString("title", options.title);
+  options.subtitle = getString("subtitle", options.subtitle);
+  options.negativeButtonText = getString("negativeButtonText", options.negativeButtonText);
+  options.allowDeviceCredential = getBool("allowDeviceCredential", options.allowDeviceCredential);
+  options.allowBiometricWeak = getBool("allowBiometricWeak", options.allowBiometricWeak);
+
+  return options;
+}
+
+void install(
+    jsi::Runtime &rt,
+    std::function<void(const char *, const char *, bool, BiometricPromptOptions)> setFn,
+    std::function<std::string(const char *, bool, BiometricPromptOptions)> getFn,
+    std::function<void(const char *, bool, BiometricPromptOptions)> delFn) {
 
   _set = setFn;
   _get = getFn;
@@ -58,8 +101,10 @@ void install(jsi::Runtime &rt,
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
 
+    BiometricPromptOptions promptOptions = extractBiometricPromptOptions(rt, params);
+
     try {
-      _set(key.c_str(), val.c_str(), withBiometrics);
+      _set(key.c_str(), val.c_str(), withBiometrics, promptOptions);
     } catch (std::exception &e) {
       auto errorStr = jsi::String::createFromUtf8(
           rt,
@@ -93,10 +138,12 @@ void install(jsi::Runtime &rt,
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
 
+    BiometricPromptOptions promptOptions = extractBiometricPromptOptions(rt, params);
+
     auto res = jsi::Object(rt);
 
     try {
-      auto val = _get(key.c_str(), withBiometrics);
+      auto val = _get(key.c_str(), withBiometrics, promptOptions);
       if (val.empty()) {
         res.setProperty(rt, "error", "[op-s2] Item not found");
       } else {
@@ -136,7 +183,9 @@ void install(jsi::Runtime &rt,
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
 
-    _del(key.c_str(), withBiometrics);
+    BiometricPromptOptions promptOptions = extractBiometricPromptOptions(rt, params);
+
+    _del(key.c_str(), withBiometrics, promptOptions);
 
     return {};
   });

--- a/android/bindings.h
+++ b/android/bindings.h
@@ -1,13 +1,25 @@
 #include <jsi/jsilib.h>
 #include <ReactCommon/CallInvoker.h>
+#include <string>
 
 namespace ops2 {
     namespace jsi = facebook::jsi;
     namespace react = facebook::react;
 
-    void install(jsi::Runtime &rt,
-                 std::function<void(const char *, const char *, bool)> setFn,
-                 std::function<std::string(const char *, bool)> getFn,
-                 std::function<void(const char *, bool)> delFn);
-}
+    // Mirrors the JS `BiometricPromptOptions` shape so we can pass it through
+    // JNI without an explosion of method overloads. Strings are owned by the
+    // struct and remain valid for the duration of the synchronous JNI call.
+    struct BiometricPromptOptions {
+        std::string title;
+        std::string subtitle;
+        std::string negativeButtonText;
+        bool allowDeviceCredential;
+        bool allowBiometricWeak;
+    };
 
+    void install(
+        jsi::Runtime &rt,
+        std::function<void(const char *, const char *, bool, BiometricPromptOptions)> setFn,
+        std::function<std::string(const char *, bool, BiometricPromptOptions)> getFn,
+        std::function<void(const char *, bool, BiometricPromptOptions)> delFn);
+}

--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -97,23 +97,55 @@ JNIEnv *GetJniEnv()
 
 jstring string2jstring(JNIEnv *env, const char *str)
 {
+    if (str == nullptr) {
+        return env->NewStringUTF("");
+    }
     return (*env).NewStringUTF(str);
 }
 
-void set(const char* key, const char* value, bool withBiometrics)
+jobject buildBiometricPromptOptions(JNIEnv *env, const ops2::BiometricPromptOptions &options)
+{
+    jclass optsClass = env->FindClass("com/op/s2/BiometricPromptOptions");
+    if (optsClass == nullptr) {
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    jmethodID optsCtor = env->GetMethodID(
+        optsClass,
+        "<init>",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZ)V"
+    );
+    if (optsCtor == nullptr) {
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    jstring jTitle = string2jstring(env, options.title.c_str());
+    jstring jSubtitle = string2jstring(env, options.subtitle.c_str());
+    jstring jNegative = string2jstring(env, options.negativeButtonText.c_str());
+
+    return env->NewObject(
+        optsClass,
+        optsCtor,
+        jTitle,
+        jSubtitle,
+        jNegative,
+        (jboolean)options.allowDeviceCredential,
+        (jboolean)options.allowBiometricWeak
+    );
+}
+
+void set(const char* key, const char* value, bool withBiometrics, ops2::BiometricPromptOptions options)
 {
     JNIEnv *jniEnv = GetJniEnv();
     java_class = jniEnv->GetObjectClass(java_object);
-    jmethodID mid = jniEnv->GetMethodID(java_class, "setItem", "(Ljava/lang/String;Ljava/lang/String;Z)V");
+    jmethodID mid = jniEnv->GetMethodID(java_class, "setItem", "(Ljava/lang/String;Ljava/lang/String;ZLcom/op/s2/BiometricPromptOptions;)V");
     jstring jKey = string2jstring(jniEnv, key);
     jstring jVal = string2jstring(jniEnv, value);
-    jvalue params[3];
-    params[0].l = jKey;
-    params[1].l = jVal;
-    params[2].z = withBiometrics;
+    jobject jOpts = buildBiometricPromptOptions(jniEnv, options);
 
-
-    jniEnv->CallVoidMethodA(java_object, mid, params);
+    jniEnv->CallVoidMethod(java_object, mid, jKey, jVal, withBiometrics, jOpts);
 
     jthrowable exObj = jniEnv->ExceptionOccurred();
     if(exObj) {
@@ -127,21 +159,18 @@ void set(const char* key, const char* value, bool withBiometrics)
         const char *mstr = jniEnv->GetStringUTFChars(message, NULL);
         throw std::runtime_error(std::string(mstr));
     }
-
 }
 
-std::string get(const char* key, bool withBiometrics)
+std::string get(const char* key, bool withBiometrics, ops2::BiometricPromptOptions options)
 {
     JNIEnv *jniEnv = GetJniEnv();
     java_class = jniEnv->GetObjectClass(java_object);
-    jmethodID mid = jniEnv->GetMethodID(java_class, "getItem", "(Ljava/lang/String;Z)Ljava/lang/String;");
+    jmethodID mid = jniEnv->GetMethodID(java_class, "getItem", "(Ljava/lang/String;ZLcom/op/s2/BiometricPromptOptions;)Ljava/lang/String;");
     jstring jKey = string2jstring(jniEnv, key);
-    jvalue params[3];
-    params[0].l = jKey;
-    params[1].z = withBiometrics;
+    jobject jOpts = buildBiometricPromptOptions(jniEnv, options);
 
+    jstring result = (jstring)jniEnv->CallObjectMethod(java_object, mid, jKey, withBiometrics, jOpts);
 
-    jstring result = (jstring)jniEnv->CallObjectMethodA(java_object, mid, params);
     jthrowable exObj = jniEnv->ExceptionOccurred();
     if(exObj) {
         jniEnv->ExceptionClear();
@@ -165,17 +194,15 @@ std::string get(const char* key, bool withBiometrics)
     return str;
 }
 
-void del(const char* key, bool withBiometrics)
+void del(const char* key, bool withBiometrics, ops2::BiometricPromptOptions options)
 {
     JNIEnv *jniEnv = GetJniEnv();
     java_class = jniEnv->GetObjectClass(java_object);
-    jmethodID mid = jniEnv->GetMethodID(java_class, "deleteItem", "(Ljava/lang/String;Z)V");
+    jmethodID mid = jniEnv->GetMethodID(java_class, "deleteItem", "(Ljava/lang/String;ZLcom/op/s2/BiometricPromptOptions;)V");
     jstring jKey = string2jstring(jniEnv, key);
-    jvalue params[2];
-    params[0].l = jKey;
-    params[1].z = withBiometrics;
+    jobject jOpts = buildBiometricPromptOptions(jniEnv, options);
 
-    jniEnv->CallVoidMethodA(java_object, mid, params);
+    jniEnv->CallVoidMethod(java_object, mid, jKey, withBiometrics, jOpts);
 }
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)

--- a/android/src/main/kotlin/com/op/s2/BiometricPromptOptions.kt
+++ b/android/src/main/kotlin/com/op/s2/BiometricPromptOptions.kt
@@ -1,0 +1,9 @@
+package com.op.s2
+
+data class BiometricPromptOptions(
+    val title: String,
+    val subtitle: String,
+    val negativeButtonText: String,
+    val allowDeviceCredential: Boolean,
+    val allowBiometricWeak: Boolean,
+)

--- a/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
+++ b/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
@@ -15,32 +15,61 @@ class OPS2Bridge(reactContext: ReactApplicationContext) {
   private val cryptoManager = CryptoManager(reactContext)
   private external fun initialize(jsiPtr: Long)
 
-  fun setItem(key: String, value: String, withBiometrics: Boolean) {
-    if(withBiometrics) {
-      val activity = this.context.currentActivity
-      val executor: Executor = ContextCompat.getMainExecutor(this.context)
-      val promptInfo = BiometricPrompt.PromptInfo.Builder()
-        .setTitle("Please authenticate")
-        .setSubtitle("Biometric authentication is required to safely read/write data")
-        .setNegativeButtonText("Cancel")
-        .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-        .build()
+  private fun buildAuthenticators(options: BiometricPromptOptions): Int {
+    var authenticators = 0
+    if (options.allowBiometricWeak) {
+      authenticators = authenticators or BiometricManager.Authenticators.BIOMETRIC_WEAK
+    } else {
+      authenticators = authenticators or BiometricManager.Authenticators.BIOMETRIC_STRONG
+    }
+    if (options.allowDeviceCredential) {
+      authenticators = authenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+    }
+    return authenticators
+  }
 
-      var mutex = Semaphore(0)
-      var authenticationCallback = TSSAuthenticationCallback(mutex)
+  private fun runBiometricPrompt(options: BiometricPromptOptions): TSSAuthenticationCallback {
+    val activity = this.context.currentActivity
+    val executor: Executor = ContextCompat.getMainExecutor(this.context)
 
-      activity?.runOnUiThread {
-        var biometricPrompt = BiometricPrompt(activity as AppCompatActivity, executor, authenticationCallback)
-        biometricPrompt.authenticate(promptInfo)
-      }
+    val authenticators = buildAuthenticators(options)
 
-      try {
-        mutex.acquire()
-      } catch (e: Exception) {
-        Log.e("BLAH", "Interrupted mutex exception");
-      }
+    val promptBuilder = BiometricPrompt.PromptInfo.Builder()
+      .setTitle(options.title)
+      .setSubtitle(options.subtitle)
+      .setAllowedAuthenticators(authenticators)
 
-      if(authenticationCallback.isAuthenticated) {
+    // setNegativeButtonText is incompatible with DEVICE_CREDENTIAL on API < 30.
+    // Only set it when the user supplied one and we are not relying on the device
+    // credential as the implicit "negative" button.
+    if (options.negativeButtonText.isNotEmpty() && !options.allowDeviceCredential) {
+      promptBuilder.setNegativeButtonText(options.negativeButtonText)
+    }
+
+    val promptInfo = promptBuilder.build()
+
+    val mutex = Semaphore(0)
+    val authenticationCallback = TSSAuthenticationCallback(mutex)
+
+    activity?.runOnUiThread {
+      val biometricPrompt = BiometricPrompt(activity as AppCompatActivity, executor, authenticationCallback)
+      biometricPrompt.authenticate(promptInfo)
+    }
+
+    try {
+      mutex.acquire()
+    } catch (e: Exception) {
+      Log.e("OPS2", "Interrupted mutex exception", e)
+    }
+
+    return authenticationCallback
+  }
+
+  fun setItem(key: String, value: String, withBiometrics: Boolean, options: BiometricPromptOptions) {
+    if (withBiometrics) {
+      val authenticationCallback = runBiometricPrompt(options)
+
+      if (authenticationCallback.isAuthenticated) {
         cryptoManager.set(key, value, true)
       } else {
         throw Exception(authenticationCallback.errorStr)
@@ -50,73 +79,25 @@ class OPS2Bridge(reactContext: ReactApplicationContext) {
     }
   }
 
-  fun getItem(key: String, withBiometrics: Boolean): String? {
+  fun getItem(key: String, withBiometrics: Boolean, options: BiometricPromptOptions): String? {
+    if (withBiometrics) {
+      val authenticationCallback = runBiometricPrompt(options)
 
-    if(withBiometrics) {
-      val activity = this.context.currentActivity
-      val executor: Executor = ContextCompat.getMainExecutor(this.context)
-      val promptInfo = BiometricPrompt.PromptInfo.Builder()
-        .setTitle("Please authenticate")
-        .setSubtitle("Biometric authentication is required to safely read/write data")
-        .setNegativeButtonText("Cancel")
-        .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-        .build()
-
-      var mutex = Semaphore(0)
-      var authenticationCallback = TSSAuthenticationCallback(mutex)
-
-      activity?.runOnUiThread {
-
-        var biometricPrompt = BiometricPrompt(activity as AppCompatActivity, executor, authenticationCallback)
-        biometricPrompt.authenticate(promptInfo)
-      }
-
-      try {
-        mutex.acquire()
-      } catch (e: Exception) {
-      }
-
-      if(authenticationCallback.isAuthenticated) {
-        val value = cryptoManager.get(key, true)
-        return value;
+      if (authenticationCallback.isAuthenticated) {
+        return cryptoManager.get(key, true)
       } else {
         throw Exception(authenticationCallback.errorStr)
       }
-
     } else {
       return cryptoManager.get(key)
     }
-
-    return null
   }
 
-  fun deleteItem(key: String, withBiometrics: Boolean) {
+  fun deleteItem(key: String, withBiometrics: Boolean, options: BiometricPromptOptions) {
+    if (withBiometrics) {
+      val authenticationCallback = runBiometricPrompt(options)
 
-    if(withBiometrics) {
-      val activity = this.context.currentActivity
-      val executor: Executor = ContextCompat.getMainExecutor(this.context)
-      val promptInfo = BiometricPrompt.PromptInfo.Builder()
-        .setTitle("Please authenticate")
-        .setSubtitle("Biometric authentication is required to safely read/write data")
-        .setNegativeButtonText("Cancel")
-        .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-        .build()
-
-      var mutex = Semaphore(0)
-      var authenticationCallback = TSSAuthenticationCallback(mutex)
-
-      activity?.runOnUiThread {
-        var biometricPrompt = BiometricPrompt(activity as AppCompatActivity, executor, authenticationCallback)
-        biometricPrompt.authenticate(promptInfo)
-      }
-
-      try {
-        mutex.acquire()
-      } catch (e: Exception) {
-
-      }
-
-      if(authenticationCallback.isAuthenticated) {
+      if (authenticationCallback.isAuthenticated) {
         cryptoManager.delete(key, true)
       } else {
         throw Exception(authenticationCallback.errorStr)

--- a/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
+++ b/android/src/main/kotlin/com/op/s2/OPS2Bridge.kt
@@ -34,14 +34,19 @@ class OPS2Bridge(reactContext: ReactApplicationContext) {
 
     val authenticators = buildAuthenticators(options)
 
+    // BiometricPrompt requires a non-empty title — fall back to a safe default
+    // if the caller passed an empty string (or one slipped through JNI).
+    val title = options.title.ifEmpty { "Please authenticate" }
+
     val promptBuilder = BiometricPrompt.PromptInfo.Builder()
-      .setTitle(options.title)
+      .setTitle(title)
       .setSubtitle(options.subtitle)
       .setAllowedAuthenticators(authenticators)
 
     // setNegativeButtonText is incompatible with DEVICE_CREDENTIAL on API < 30.
     // Only set it when the user supplied one and we are not relying on the device
-    // credential as the implicit "negative" button.
+    // credential as the implicit "negative" button. Also guard against an
+    // empty string — BiometricPrompt throws if you call it with "".
     if (options.negativeButtonText.isNotEmpty() && !options.allowDeviceCredential) {
       promptBuilder.setNegativeButtonText(options.negativeButtonText)
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.79.2):
     - hermes-engine/Pre-built (= 0.79.2)
   - hermes-engine/Pre-built (0.79.2)
-  - op-s2 (0.1.11):
+  - op-s2 (0.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1913,7 +1913,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
-  op-s2: 1cea9ab38f711d9df323b21c0cfd0a21ea751b1b
+  op-s2: 32f71b1b73ca16c0572c2babfa3297ef996234c8
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e

--- a/example/src/tests/s2.ts
+++ b/example/src/tests/s2.ts
@@ -1,5 +1,11 @@
-import { del, get, set } from '@op-engineering/op-s2';
+import { del, get, set, ACCESSIBILITY } from '@op-engineering/op-s2';
 import { describe, expect, it } from '@op-engineering/op-test';
+
+// Toggle to `true` when running on a simulator/emulator (where biometrics are
+// not enrolled and the prompt short-circuits with "Biometrics not available").
+// Leave `false` on physical devices — the Face ID / passcode prompt would
+// otherwise block the test suite waiting for user interaction.
+const RUN_BIOMETRIC_TESTS = false;
 
 describe('securely storage/retrieve', () => {
   it('set/get', () => {
@@ -71,3 +77,289 @@ describe('securely storage/retrieve', () => {
     expect(error2).toEqual('[op-s2] Item not found');
   });
 });
+
+describe('accessibility option (iOS)', () => {
+  it('set/get with WHEN_UNLOCKED accessibility', () => {
+    const key = 'key5';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.WHEN_UNLOCKED,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+
+  it('set/get with WHEN_PASSCODE_SET_THIS_DEVICE_ONLY accessibility', () => {
+    const key = 'key6';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+
+  it('set/get with AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY accessibility', () => {
+    const key = 'key7';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+});
+
+if (RUN_BIOMETRIC_TESTS) {
+  describe('biometricPrompt options', () => {
+    it('set/get with only title/subtitle (defaults: no device credential, strong biometric)', () => {
+      const key = 'key8';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueDefault',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Default title',
+          subtitle: 'Default subtitle',
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Default read',
+          subtitle: 'Default read subtitle',
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueDefault');
+
+      del({ key });
+    });
+
+    it('set/get with allowDeviceCredential: true', () => {
+      const key = 'key9';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueDeviceCredTrue',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Auth with device credential',
+          subtitle: 'Strong biometric OR passcode',
+          allowDeviceCredential: true,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Read with device credential',
+          subtitle: 'Strong biometric OR passcode',
+          allowDeviceCredential: true,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueDeviceCredTrue');
+
+      del({ key });
+    });
+
+    it('set/get with allowDeviceCredential: false', () => {
+      const key = 'key10';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueDeviceCredFalse',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Auth strong biometric only',
+          subtitle: 'No passcode fallback',
+          allowDeviceCredential: false,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Read strong biometric only',
+          subtitle: 'No passcode fallback',
+          allowDeviceCredential: false,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueDeviceCredFalse');
+
+      del({ key });
+    });
+
+    it('set/get with allowBiometricWeak: true', () => {
+      const key = 'key11';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueWeakTrue',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Auth weak biometric',
+          subtitle: 'Class 2 biometrics accepted',
+          allowDeviceCredential: false,
+          allowBiometricWeak: true,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Read weak biometric',
+          subtitle: 'Class 2 biometrics accepted',
+          allowDeviceCredential: false,
+          allowBiometricWeak: true,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueWeakTrue');
+
+      del({ key });
+    });
+
+    it('set/get with allowBiometricWeak: false', () => {
+      const key = 'key12';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueWeakFalse',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Auth strong biometric only',
+          subtitle: 'Class 3 biometrics required',
+          allowDeviceCredential: false,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Read strong biometric only',
+          subtitle: 'Class 3 biometrics required',
+          allowDeviceCredential: false,
+          allowBiometricWeak: false,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueWeakFalse');
+
+      del({ key });
+    });
+
+    it('set/get with allowDeviceCredential: true and allowBiometricWeak: true', () => {
+      const key = 'key13';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueBoth',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Auth weak biometric + passcode',
+          subtitle: 'Most permissive combination',
+          allowDeviceCredential: true,
+          allowBiometricWeak: true,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: 'Read weak biometric + passcode',
+          subtitle: 'Most permissive combination',
+          allowDeviceCredential: true,
+          allowBiometricWeak: true,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueBoth');
+
+      del({ key });
+    });
+
+    it('set/get with withBiometrics: true and NO biometricPrompt (uses all defaults)', () => {
+      const key = 'key14';
+
+      // Only withBiometrics is passed — no biometricPrompt object at all.
+      // The native layer should fall back to:
+      //   title = "Please authenticate", subtitle = "", negativeButtonText = "Cancel",
+      //   allowDeviceCredential = false, allowBiometricWeak = false
+      const { error: setError } = set({
+        key,
+        value: 'myValueNoPrompt',
+        withBiometrics: true,
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueNoPrompt');
+
+      del({ key });
+    });
+  });
+}

--- a/example/src/tests/s2.ts
+++ b/example/src/tests/s2.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from '@op-engineering/op-test';
 // not enrolled and the prompt short-circuits with "Biometrics not available").
 // Leave `false` on physical devices — the Face ID / passcode prompt would
 // otherwise block the test suite waiting for user interaction.
-const RUN_BIOMETRIC_TESTS = true;
+const RUN_BIOMETRIC_TESTS = false;
 
 describe('securely storage/retrieve', () => {
   it('set/get', () => {

--- a/example/src/tests/s2.ts
+++ b/example/src/tests/s2.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from '@op-engineering/op-test';
 // not enrolled and the prompt short-circuits with "Biometrics not available").
 // Leave `false` on physical devices — the Face ID / passcode prompt would
 // otherwise block the test suite waiting for user interaction.
-const RUN_BIOMETRIC_TESTS = false;
+const RUN_BIOMETRIC_TESTS = true;
 
 describe('securely storage/retrieve', () => {
   it('set/get', () => {
@@ -122,6 +122,60 @@ describe('accessibility option (iOS)', () => {
       key,
       value: 'myValue',
       accessibility: ACCESSIBILITY.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+
+  it('set/get with WHEN_UNLOCKED_THIS_DEVICE_ONLY accessibility (covers int code 6)', () => {
+    const key = 'key_unlocked_this_device_only';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+
+  it('set/get with ALWAYS accessibility', () => {
+    const key = 'key_always';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.ALWAYS,
+    });
+
+    expect(setError).toBe(undefined);
+
+    const { value, error } = get({ key });
+    expect(error).toBe(undefined);
+    expect(value).toEqual('myValue');
+
+    del({ key });
+  });
+
+  it('set/get with ALWAYS_THIS_DEVICE_ONLY accessibility', () => {
+    const key = 'key_always_this_device_only';
+
+    const { error: setError } = set({
+      key,
+      value: 'myValue',
+      accessibility: ACCESSIBILITY.ALWAYS_THIS_DEVICE_ONLY,
     });
 
     expect(setError).toBe(undefined);
@@ -358,6 +412,40 @@ if (RUN_BIOMETRIC_TESTS) {
 
       expect(error).toBe(undefined);
       expect(value).toEqual('myValueNoPrompt');
+
+      del({ key });
+    });
+
+    it('set/get with empty title in biometricPrompt (falls back to default)', () => {
+      // Regression: an empty `title` would crash BiometricPrompt on Android
+      // because setTitle requires a non-empty CharSequence. The native layer
+      // must treat "" the same as a missing property.
+      const key = 'key_empty_title';
+
+      const { error: setError } = set({
+        key,
+        value: 'myValueEmptyTitle',
+        withBiometrics: true,
+        biometricPrompt: {
+          title: '',
+          negativeButtonText: '',
+          allowDeviceCredential: true,
+        },
+      });
+
+      expect(setError).toBe(undefined);
+
+      const { value, error } = get({
+        key,
+        withBiometrics: true,
+        biometricPrompt: {
+          title: '',
+          allowDeviceCredential: true,
+        },
+      });
+
+      expect(error).toBe(undefined);
+      expect(value).toEqual('myValueEmptyTitle');
 
       del({ key });
     });

--- a/ios/bindings.mm
+++ b/ios/bindings.mm
@@ -45,11 +45,17 @@ static BiometricPromptArgs extractBiometricPromptArgs(jsi::Runtime &rt, const js
     if (!prop.isNull() && !prop.isUndefined() && prop.isObject()) {
       jsi::Object prompt = prop.asObject(rt);
 
-      auto getString = [&](const char *name, const std::string &fallback) -> std::string {
+      // For `title` and `negativeButtonText`, the native side (Android
+      // BiometricPrompt in particular) requires a non-empty value. Treat an
+      // empty string the same as a missing property so we always fall back
+      // to a safe default.
+      auto getString = [&](const char *name, const std::string &fallback, bool allowEmpty = true) -> std::string {
         if (!prompt.hasProperty(rt, name)) return fallback;
         jsi::Value v = prompt.getProperty(rt, name);
         if (!v.isString()) return fallback;
-        return v.asString(rt).utf8(rt);
+        std::string s = v.asString(rt).utf8(rt);
+        if (!allowEmpty && s.empty()) return fallback;
+        return s;
       };
 
       auto getBool = [&](const char *name, bool fallback) -> bool {
@@ -59,9 +65,9 @@ static BiometricPromptArgs extractBiometricPromptArgs(jsi::Runtime &rt, const js
         return v.getBool();
       };
 
-      args.title = getString("title", args.title);
-      args.subtitle = getString("subtitle", args.subtitle);
-      args.negativeButtonText = getString("negativeButtonText", args.negativeButtonText);
+      args.title = getString("title", args.title, /*allowEmpty=*/false);
+      args.subtitle = getString("subtitle", args.subtitle, /*allowEmpty=*/true);
+      args.negativeButtonText = getString("negativeButtonText", args.negativeButtonText, /*allowEmpty=*/false);
       args.allowDeviceCredential = getBool("allowDeviceCredential", args.allowDeviceCredential);
       args.allowBiometricWeak = getBool("allowBiometricWeak", args.allowBiometricWeak);
     }
@@ -160,6 +166,7 @@ CFStringRef getAccessibilityValue(int accessibility) {
     case 3: return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
     case 4: return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
     case 5: return kSecAttrAccessibleAlwaysThisDeviceOnly;
+    case 6: return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     default: return kSecAttrAccessibleAfterFirstUnlock;
   }
 }

--- a/ios/bindings.mm
+++ b/ios/bindings.mm
@@ -2,9 +2,18 @@
 #import "macros.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 #import <Security/Security.h>
+#import <dispatch/dispatch.h>
 
 namespace ops2 {
 namespace jsi = facebook::jsi;
+
+struct BiometricPromptArgs {
+  std::string title;
+  std::string subtitle;
+  std::string negativeButtonText;
+  bool allowDeviceCredential;
+  bool allowBiometricWeak;
+};
 
 typedef enum {
   kBiometricsStateAvailable,
@@ -12,13 +21,96 @@ typedef enum {
   kBiometricsStateLocked
 } BiometricsState;
 
-BiometricsState getBiometricsState() {
+// MARK: - Memory Hygiene Helper
+static void zeroizeString(std::string &str) {
+  if (!str.empty()) {
+    memset(&str[0], 0, str.size());
+  }
+}
+
+static NSString *stringToNSString(const std::string &str) {
+  return [NSString stringWithUTF8String:str.c_str()];
+}
+
+static BiometricPromptArgs extractBiometricPromptArgs(jsi::Runtime &rt, const jsi::Object &params) {
+  BiometricPromptArgs args;
+  args.title = "Please authenticate";
+  args.subtitle = "";
+  args.negativeButtonText = "Cancel";
+  args.allowDeviceCredential = false;
+  args.allowBiometricWeak = false;
+
+  if (params.hasProperty(rt, "biometricPrompt")) {
+    jsi::Value prop = params.getProperty(rt, "biometricPrompt");
+    if (!prop.isNull() && !prop.isUndefined() && prop.isObject()) {
+      jsi::Object prompt = prop.asObject(rt);
+
+      auto getString = [&](const char *name, const std::string &fallback) -> std::string {
+        if (!prompt.hasProperty(rt, name)) return fallback;
+        jsi::Value v = prompt.getProperty(rt, name);
+        if (!v.isString()) return fallback;
+        return v.asString(rt).utf8(rt);
+      };
+
+      auto getBool = [&](const char *name, bool fallback) -> bool {
+        if (!prompt.hasProperty(rt, name)) return fallback;
+        jsi::Value v = prompt.getProperty(rt, name);
+        if (!v.isBool()) return fallback;
+        return v.getBool();
+      };
+
+      args.title = getString("title", args.title);
+      args.subtitle = getString("subtitle", args.subtitle);
+      args.negativeButtonText = getString("negativeButtonText", args.negativeButtonText);
+      args.allowDeviceCredential = getBool("allowDeviceCredential", args.allowDeviceCredential);
+      args.allowBiometricWeak = getBool("allowBiometricWeak", args.allowBiometricWeak);
+    }
+  }
+
+  return args;
+}
+
+// MARK: - LAContext Factory
+static LAContext *createLAContext(const BiometricPromptArgs &args) {
+  LAContext *context = [[LAContext alloc] init];
+
+  // iOS does not expose a native subtitle field on the LAContext prompt.
+  // When the caller provides one, append it to the localizedReason so the user still sees it.
+  std::string reason = args.title;
+  if (!args.subtitle.empty()) {
+    reason += "\n";
+    reason += args.subtitle;
+  }
+  NSString *localizedReason = stringToNSString(reason);
+  if (localizedReason.length > 0) {
+    context.localizedReason = localizedReason;
+  }
+
+  NSString *cancel = stringToNSString(args.negativeButtonText);
+  if (cancel.length > 0) {
+    context.localizedCancelTitle = cancel;
+  }
+
+  // Hide the fallback button if device credential fallback is not allowed
+  if (!args.allowDeviceCredential) {
+    context.localizedFallbackTitle = @"";
+  }
+
+  return context;
+}
+
+BiometricsState getBiometricsState(bool allowDeviceCredential) {
   LAContext *myContext = [[LAContext alloc] init];
   NSError *authError = nil;
 
-  if ([myContext
-          canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-                      error:&authError]) {
+  // When the caller accepts the device passcode as a fallback, switch to the
+  // "biometrics OR passcode" policy so users without enrolled biometrics can
+  // still authenticate via the keychain.
+  LAPolicy policy = allowDeviceCredential
+      ? LAPolicyDeviceOwnerAuthentication
+      : LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+
+  if ([myContext canEvaluatePolicy:policy error:&authError]) {
     return kBiometricsStateAvailable;
   } else {
     if (authError.code == LAErrorBiometryLockout) {
@@ -29,59 +121,74 @@ BiometricsState getBiometricsState() {
   }
 }
 
-SecAccessControlRef getBioSecAccessControl() {
+SecAccessControlRef createBioSecAccessControl(bool allowDeviceCredential, bool allowBiometricWeak) {
+  // `kSecAccessControlBiometryAny` matches any enrolled biometric (looser — closer to Android
+  // Class 2 / WEAK). `kSecAccessControlBiometryCurrentSet` requires the current set of
+  // enrolled biometrics (tighter — closer to Android Class 3 / STRONG).
+  SecAccessControlCreateFlags biometryFlag = allowBiometricWeak
+      ? kSecAccessControlBiometryAny
+      : kSecAccessControlBiometryCurrentSet;
+
+  SecAccessControlCreateFlags flags = allowDeviceCredential
+      ? (biometryFlag | kSecAccessControlOr | kSecAccessControlDevicePasscode)
+      : biometryFlag;
+
   return SecAccessControlCreateWithFlags(
-      kCFAllocatorDefault,                             // default allocator
-      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, // Require passcode to be
-                                                       // set on device
-      kSecAccessControlUserPresence, // checks for user presence with touchID,
-                                     // faceID or passcode :)
-      nil);                          // Error pointer
+      kCFAllocatorDefault,
+      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+      flags,
+      nil);
 }
 
 NSMutableDictionary *get_base_entry_dict(std::string key) {
   NSMutableDictionary *queryDictionary = [[NSMutableDictionary alloc] init];
-  [queryDictionary setObject:(id)kSecClassGenericPassword forKey:(id)kSecClass];
+  [queryDictionary setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
 
-  NSData *encodedIdentifier = [NSData dataWithBytes:key.data()
-                                             length:key.length()];
-  [queryDictionary setObject:encodedIdentifier forKey:(id)kSecAttrGeneric];
-  [queryDictionary setObject:encodedIdentifier forKey:(id)kSecAttrAccount];
-
-  [queryDictionary setObject:[[NSBundle mainBundle] bundleIdentifier]
-                      forKey:(id)kSecAttrService];
+  NSData *encodedIdentifier = [NSData dataWithBytes:key.data() length:key.length()];
+  [queryDictionary setObject:encodedIdentifier forKey:(__bridge id)kSecAttrGeneric];
+  [queryDictionary setObject:encodedIdentifier forKey:(__bridge id)kSecAttrAccount];
+  [queryDictionary setObject:[[NSBundle mainBundle] bundleIdentifier] forKey:(__bridge id)kSecAttrService];
 
   return queryDictionary;
 }
 
 CFStringRef getAccessibilityValue(int accessibility) {
   switch (accessibility) {
-  case 0:
-    return kSecAttrAccessibleWhenUnlocked;
-  case 1:
-    return kSecAttrAccessibleAfterFirstUnlock;
-  case 2:
-    return kSecAttrAccessibleAlways;
-  case 3:
-    return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
-  case 4:
-    return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
-  case 5:
-    return kSecAttrAccessibleAlwaysThisDeviceOnly;
-  default:
-    return kSecAttrAccessibleAfterFirstUnlock;
+    case 0: return kSecAttrAccessibleWhenUnlocked;
+    case 1: return kSecAttrAccessibleAfterFirstUnlock;
+    case 2: return kSecAttrAccessibleAlways;
+    case 3: return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+    case 4: return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+    case 5: return kSecAttrAccessibleAlwaysThisDeviceOnly;
+    default: return kSecAttrAccessibleAfterFirstUnlock;
   }
-
-  return kSecAttrAccessibleAfterFirstUnlock;
 }
 
+// Robust deletion that removes both local and iCloud-synced items.
+// When `withBiometrics` is false we tell the keychain NOT to surface any
+// authentication UI — otherwise deleting an entry that was previously stored
+// with biometric protection would pop the Face ID / passcode prompt even
+// though the caller explicitly opted out of biometrics.
 void _delete(std::string &key, bool withBiometrics) {
   NSMutableDictionary *dict = get_base_entry_dict(key);
-  if (withBiometrics) {
-    [dict setObject:(__bridge id)getBioSecAccessControl()
-             forKey:(id)kSecAttrAccessControl];
+  [dict setObject:(__bridge id)kSecAttrSynchronizableAny forKey:(__bridge id)kSecAttrSynchronizable];
+  if (!withBiometrics) {
+    [dict setObject:(__bridge id)kSecUseAuthenticationUIFail forKey:(__bridge id)kSecUseAuthenticationUI];
   }
-  SecItemDelete((CFDictionaryRef)dict);
+  SecItemDelete((__bridge CFDictionaryRef)dict);
+}
+
+// Thread-safe dispatch for Keychain APIs that present authentication UI
+static OSStatus performCopyMatching(CFDictionaryRef query, CFTypeRef *result) {
+  if ([NSThread isMainThread]) {
+    return SecItemCopyMatching(query, result);
+  }
+
+  __block OSStatus status;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    status = SecItemCopyMatching(query, result);
+  });
+  return status;
 }
 
 std::string getSecurityErrorMessage(OSStatus status) {
@@ -113,31 +220,20 @@ void setSecurityError(jsi::Runtime &rt, jsi::Object &res, OSStatus status) {
   }
 }
 
-void install(jsi::Runtime &rt,
-             std::shared_ptr<react::CallInvoker> jsCallInvoker) {
+void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker) {
+
   auto set = HOSTFN("set", 1) {
     auto res = jsi::Object(rt);
-    CFStringRef accessibility = kSecAttrAccessibleAfterFirstUnlock;
 
-    if (count < 1) {
-      res.setProperty(rt, "error", "Params object is missing");
-      return res;
-    }
-
-    if (!args[0].isObject()) {
-      res.setProperty(rt, "error", "Params is not an object");
+    if (count < 1 || !args[0].isObject()) {
+      res.setProperty(rt, "error", "Params must be an object");
       return res;
     }
 
     jsi::Object params = args[0].asObject(rt);
 
-    if (!params.hasProperty(rt, "key")) {
-      res.setProperty(rt, "error", "Key property is missing");
-      return res;
-    }
-
-    if (!params.hasProperty(rt, "value")) {
-      res.setProperty(rt, "error", "Value property is missing");
+    if (!params.hasProperty(rt, "key") || !params.hasProperty(rt, "value")) {
+      res.setProperty(rt, "error", "Key or Value property is missing");
       return res;
     }
 
@@ -149,36 +245,54 @@ void install(jsi::Runtime &rt,
     std::string key = params.getProperty(rt, "key").asString(rt).utf8(rt);
     std::string val = params.getProperty(rt, "value").asString(rt).utf8(rt);
 
-    if (params.hasProperty(rt, "accessibility")) {
-      if (params.getProperty(rt, "accessibility").isNumber()) {
-        accessibility = getAccessibilityValue(static_cast<int>(
-            params.getProperty(rt, "accessibility").asNumber()));
-      }
+    CFStringRef accessibility = kSecAttrAccessibleAfterFirstUnlock;
+    if (params.hasProperty(rt, "accessibility") && params.getProperty(rt, "accessibility").isNumber()) {
+      accessibility = getAccessibilityValue(static_cast<int>(params.getProperty(rt, "accessibility").asNumber()));
     }
 
     bool withBiometrics = false;
-
     if (params.hasProperty(rt, "withBiometrics")) {
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
 
+    BiometricPromptArgs promptArgs = extractBiometricPromptArgs(rt, params);
+
+    if (withBiometrics) {
+      BiometricsState biometricsState = getBiometricsState(promptArgs.allowDeviceCredential);
+      if (biometricsState == kBiometricsStateNotAvailable) {
+        auto errorStr = jsi::String::createFromUtf8(rt, "Biometrics not available");
+        res.setProperty(rt, "error", errorStr);
+        return res;
+      }
+    }
+
+    // Delete prior entries (both local and synced) to prevent errSecDuplicateItem
     _delete(key, withBiometrics);
 
     NSMutableDictionary *dict = get_base_entry_dict(key);
 
-    // kSecAttrAccessControl is mutually excluse with kSecAttrAccessible
-    // https://mobile-security.gitbook.io/mobile-security-testing-guide/ios-testing-guide/0x06f-testing-local-authentication
     if (withBiometrics) {
-      [dict setObject:(__bridge_transfer id)getBioSecAccessControl()
-               forKey:(id)kSecAttrAccessControl];
+      SecAccessControlRef accessControl = createBioSecAccessControl(promptArgs.allowDeviceCredential, promptArgs.allowBiometricWeak);
+      if (accessControl) {
+        [dict setObject:(__bridge_transfer id)accessControl forKey:(__bridge id)kSecAttrAccessControl];
+      }
+      [dict setObject:createLAContext(promptArgs) forKey:(__bridge id)kSecUseAuthenticationContext];
+
+      NSString *promptTitle = stringToNSString(promptArgs.title);
+      if (promptTitle.length > 0) {
+        [dict setObject:promptTitle forKey:(__bridge id)kSecUseOperationPrompt];
+      }
     } else {
-      [dict setObject:(__bridge id)accessibility forKey:(id)kSecAttrAccessible];
+      [dict setObject:(__bridge id)accessibility forKey:(__bridge id)kSecAttrAccessible];
     }
 
     NSData *data = [NSData dataWithBytes:val.data() length:val.length()];
-    [dict setObject:data forKey:(id)kSecValueData];
+    [dict setObject:data forKey:(__bridge id)kSecValueData];
 
-    OSStatus status = SecItemAdd((CFDictionaryRef)dict, NULL);
+    OSStatus status = SecItemAdd((__bridge CFDictionaryRef)dict, NULL);
+
+    // Zeroize sensitive memory from input parameter
+    zeroizeString(val);
 
     if (status != noErr) {
       setSecurityError(rt, res, status);
@@ -188,12 +302,8 @@ void install(jsi::Runtime &rt,
   });
 
   auto get = HOSTFN("get", 1) {
-    if (count < 1) {
-      throw jsi::JSError(rt, "Params object is missing");
-    }
-
-    if (!args[0].isObject()) {
-      throw jsi::JSError(rt, "Params must be an object with key and value");
+    if (count < 1 || !args[0].isObject()) {
+      throw jsi::JSError(rt, "Params must be an object with key");
     }
 
     jsi::Object params = args[0].asObject(rt);
@@ -205,65 +315,54 @@ void install(jsi::Runtime &rt,
     std::string key = params.getProperty(rt, "key").asString(rt).utf8(rt);
 
     bool withBiometrics = false;
-
     if (params.hasProperty(rt, "withBiometrics")) {
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
 
+    BiometricPromptArgs promptArgs = extractBiometricPromptArgs(rt, params);
+
     NSMutableDictionary *dict = get_base_entry_dict(key);
 
-    [dict setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
-    [dict setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+    [dict setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
+    [dict setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnData];
 
     auto res = jsi::Object(rt);
 
     if (withBiometrics) {
-      BiometricsState biometricsState = getBiometricsState();
-      LAContext *authContext = [[LAContext alloc] init];
+      BiometricsState biometricsState = getBiometricsState(promptArgs.allowDeviceCredential);
 
-      // If device has no passcode/faceID/touchID then wallet-core cannot read
-      // the value from memory
       if (biometricsState == kBiometricsStateNotAvailable) {
-        auto errorStr =
-            jsi::String::createFromUtf8(rt, "Biometrics not available");
-
+        auto errorStr = jsi::String::createFromUtf8(rt, "Biometrics not available");
         res.setProperty(rt, "error", errorStr);
-
         return res;
       }
 
-      if (biometricsState == kBiometricsStateLocked) {
+      // Create and attach the fully configured LAContext
+      [dict setObject:createLAContext(promptArgs) forKey:(__bridge id)kSecUseAuthenticationContext];
 
-        // TODO receiving a localized string might be necessary if this is
-        // happening on production
-        [authContext
-             evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-            localizedReason:@"You need to unlock your device"
-                      reply:^(BOOL success, NSError *error) {
-                        if (!success) {
-                          // Edge case when device might locked out after too
-                          // many password attempts User has failed to
-                          // authenticate, but due to this being a callback
-                          // cannot interrupt upper lexical scope We should
-                          // somehow prompt/tell the user that it has failed to
-                          // authenticate and wallet could not be loaded
-                        }
-                      }];
+      NSString *promptTitle = stringToNSString(promptArgs.title);
+      if (promptTitle.length > 0) {
+        [dict setObject:promptTitle forKey:(__bridge id)kSecUseOperationPrompt];
       }
 
-      [dict setObject:(__bridge id)getBioSecAccessControl()
-               forKey:(id)kSecAttrAccessControl];
+      SecAccessControlRef accessControl = createBioSecAccessControl(promptArgs.allowDeviceCredential, promptArgs.allowBiometricWeak);
+      if (accessControl) {
+        [dict setObject:(__bridge_transfer id)accessControl forKey:(__bridge id)kSecAttrAccessControl];
+      }
     }
 
     CFDataRef dataResult = nil;
-    OSStatus status =
-        SecItemCopyMatching((CFDictionaryRef)dict, (CFTypeRef *)&dataResult);
+    // Execute copy matching on the Main Thread to ensure proper UI rendering for Face ID
+    OSStatus status = performCopyMatching((__bridge CFDictionaryRef)dict, (CFTypeRef *)&dataResult);
 
     if (status == noErr) {
-      NSData *result = (__bridge NSData *)dataResult;
-      NSString *returnString =
-          [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
-      res.setProperty(rt, "value", [returnString UTF8String]);
+      NSData *result = (__bridge_transfer NSData *)dataResult;
+      NSString *returnString = [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
+
+      std::string resultStr = [returnString UTF8String] ? [returnString UTF8String] : "";
+      res.setProperty(rt, "value", jsi::String::createFromUtf8(rt, resultStr));
+
+      zeroizeString(resultStr);
       return res;
     }
 
@@ -272,12 +371,8 @@ void install(jsi::Runtime &rt,
   });
 
   auto del = HOSTFN("delete", 1) {
-    if (count < 1) {
-      throw jsi::JSError(rt, "Params object is missing");
-    }
-
-    if (!args[0].isObject()) {
-      throw jsi::JSError(rt, "Params must be an object with key and value");
+    if (count < 1 || !args[0].isObject()) {
+      throw jsi::JSError(rt, "Params must be an object with key");
     }
 
     jsi::Object params = args[0].asObject(rt);
@@ -287,15 +382,13 @@ void install(jsi::Runtime &rt,
     }
 
     std::string key = params.getProperty(rt, "key").asString(rt).utf8(rt);
-
+    
     bool withBiometrics = false;
-
     if (params.hasProperty(rt, "withBiometrics")) {
       withBiometrics = params.getProperty(rt, "withBiometrics").asBool();
     }
-
+    
     _delete(key, withBiometrics);
-
     return {};
   });
 
@@ -307,4 +400,5 @@ void install(jsi::Runtime &rt,
 
   rt.global().setProperty(rt, "__OPS2Proxy", std::move(module));
 }
+
 } // namespace ops2

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -182,6 +182,7 @@ const ACCESSIBILITY_TO_INT: Record<string, number> = {
   AccessibleWhenPasscodeSetThisDeviceOnly: 3,
   AccessibleAfterFirstUnlockThisDeviceOnly: 4,
   AccessibleAlwaysThisDeviceOnly: 5,
+  AccessibleWhenUnlockedThisDeviceOnly: 6,
 };
 
 function normalizeAccessibility(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,9 +78,36 @@ export enum ACCESSIBILITY {
   WHEN_UNLOCKED_THIS_DEVICE_ONLY = 'AccessibleWhenUnlockedThisDeviceOnly',
 }
 
-export const get = proxy.get;
-export const set = proxy.set;
-export const del = proxy.del;
+interface BiometricPromptOptions {
+  /**
+   * Title shown on the biometric/device credential prompt.
+   */
+  title?: string;
+  /**
+   * Subtitle shown beneath the title on the biometric/device credential prompt.
+   * (iOS does not have a native subtitle field; when provided it is appended to the title.)
+   */
+  subtitle?: string;
+  /**
+   * Label of the negative (cancel) button.
+   */
+  negativeButtonText?: string;
+  /**
+   * Allow the device passcode (PIN/pattern/password) as an alternative to biometrics.
+   * Maps to:
+   * - iOS: `kSecAttrAccessControlDevicePasscode` and `LAPolicyDeviceOwnerAuthentication`
+   * - Android: `BiometricManager.Authenticators.DEVICE_CREDENTIAL`
+   * Defaults to `false`.
+   */
+  allowDeviceCredential?: boolean;
+  /**
+   * Allow Class 2 (weak) biometrics on Android (e.g. face/iris without strict hardware backing).
+   * On iOS this maps to `kSecAccessControlBiometryAny` instead of
+   * `kSecAccessControlBiometryCurrentSet` (less strict re-enrollment check).
+   * Defaults to `false` (strong biometrics only).
+   */
+  allowBiometricWeak?: boolean;
+}
 
 type SharedOperationErrors =
   | '[op-s2] User cancelled authentication'
@@ -107,17 +134,101 @@ type GetErrors =
   | 'Biometrics not available'
   | SharedOperationErrors;
 
-interface OPS2 {
-  set: (params: {
-    key: string;
-    value: string;
-    withBiometrics?: boolean;
-    accessibility?: ACCESSIBILITY;
-  }) => { error?: SetErrors };
-  get: (params: {
-    key: string;
-    withBiometrics?: boolean;
-    accessibility?: ACCESSIBILITY;
-  }) => { value: string | undefined; error?: GetErrors };
-  del: (params: { key: string; withBiometrics?: boolean }) => void;
+interface SetParams {
+  key: string;
+  value: string;
+  /**
+   * iOS only: the keychain accessibility class. Mutually exclusive with
+   * `withBiometrics` on iOS.
+   */
+  accessibility?: ACCESSIBILITY;
+  /**
+   * Require biometric (and/or device credential) authentication before
+   * reading or writing the value.
+   */
+  withBiometrics?: boolean;
+  /**
+   * Customize the biometric prompt and the accepted authenticators.
+   */
+  biometricPrompt?: BiometricPromptOptions;
 }
+
+interface GetParams {
+  key: string;
+  accessibility?: ACCESSIBILITY;
+  withBiometrics?: boolean;
+  biometricPrompt?: BiometricPromptOptions;
+}
+
+interface OPS2 {
+  set: (params: SetParams) => { error?: SetErrors };
+  get: (params: GetParams) => { value: string | undefined; error?: GetErrors };
+  del: (params: {
+    key: string;
+    withBiometrics?: boolean;
+    biometricPrompt?: BiometricPromptOptions;
+  }) => void;
+}
+
+// Map the string-based ACCESSIBILITY enum to the integer codes the iOS
+// keychain expects. Android ignores this value, so the translation is harmless
+// on that platform. Keeping the public enum as strings means existing
+// consumers don't need to change anything — we normalize internally before
+// hitting the native side.
+const ACCESSIBILITY_TO_INT: Record<string, number> = {
+  AccessibleWhenUnlocked: 0,
+  AccessibleAfterFirstUnlock: 1,
+  AccessibleAlways: 2,
+  AccessibleWhenPasscodeSetThisDeviceOnly: 3,
+  AccessibleAfterFirstUnlockThisDeviceOnly: 4,
+  AccessibleAlwaysThisDeviceOnly: 5,
+};
+
+function normalizeAccessibility(
+  value: ACCESSIBILITY | undefined
+): number | undefined {
+  if (value === undefined) return undefined;
+  const mapped = ACCESSIBILITY_TO_INT[value as string];
+  return mapped ?? 1; // default to kSecAttrAccessibleAfterFirstUnlock
+}
+
+type NativeSetParams = {
+  key: string;
+  value: string;
+  accessibility?: number;
+  withBiometrics?: boolean;
+  biometricPrompt?: BiometricPromptOptions;
+};
+
+type NativeGetParams = {
+  key: string;
+  accessibility?: number;
+  withBiometrics?: boolean;
+  biometricPrompt?: BiometricPromptOptions;
+};
+
+function normalizeSetParams(params: SetParams): NativeSetParams {
+  return {
+    ...params,
+    accessibility: normalizeAccessibility(params.accessibility),
+  };
+}
+
+function normalizeGetParams(params: GetParams): NativeGetParams {
+  return {
+    ...params,
+    accessibility: normalizeAccessibility(params.accessibility),
+  };
+}
+
+export const set: OPS2['set'] = (params) =>
+  proxy.set(
+    normalizeSetParams(params) as unknown as Parameters<typeof proxy.set>[0]
+  );
+
+export const get: OPS2['get'] = (params) =>
+  proxy.get(
+    normalizeGetParams(params) as unknown as Parameters<typeof proxy.get>[0]
+  );
+
+export const del = proxy.del;


### PR DESCRIPTION
## Summary

This PR exposes the previously undocumented `biometricPrompt` options on
`set` / `get` / `del`, adds support for `BIOMETRIC_WEAK` and `DEVICE_CREDENTIAL`
on Android, and fixes a long-standing bug where the public `ACCESSIBILITY` enum
was being silently ignored on iOS because the native side only accepted
`number` values.

The public API surface is fully backward compatible — the existing string-based
`ACCESSIBILITY` enum is preserved, the new options are purely additive, and the
new defaults match the previous hard-coded behaviour.

## What changed

### New API: `biometricPrompt`

`set` and `get` (and now `del`) accept a `biometricPrompt` object:

```ts
{
  title?: string;
  subtitle?: string;
  negativeButtonText?: string;
  allowDeviceCredential?: boolean;   // default false
  allowBiometricWeak?: boolean;      // default false
}
```

All fields are optional. When omitted the previous defaults are used:
`title = "Please authenticate"`, `subtitle = ""`,
`negativeButtonText = "Cancel"`, both flags `false`.

#### iOS mapping

| `biometricPrompt` field         | Native effect                                                                       |
| ------------------------------- | ----------------------------------------------------------------------------------- |
| `title`                         | `LAContext.localizedReason` (appended with subtitle)                                |
| `subtitle`                      | Appended to the localized reason (LAContext has no native subtitle slot)             |
| `negativeButtonText`            | `LAContext.localizedCancelTitle`                                                    |
| `allowDeviceCredential`         | Adds `kSecAccessControlDevicePasscode` to the access control + `LAPolicyDeviceOwnerAuthentication` (instead of `...WithBiometrics`) |
| `allowBiometricWeak`            | Uses `kSecAccessControlBiometryAny` instead of `kSecAccessControlBiometryCurrentSet` |

#### Android mapping

| `biometricPrompt` field         | Native effect                                                                       |
| ------------------------------- | ----------------------------------------------------------------------------------- |
| `title` / `subtitle`            | `BiometricPrompt.PromptInfo.setTitle` / `setSubtitle`                               |
| `negativeButtonText`            | `setNegativeButtonText` — omitted when `allowDeviceCredential` is true (incompatible with `DEVICE_CREDENTIAL` on API < 30) |
| `allowDeviceCredential`         | OR's in `BiometricManager.Authenticators.DEVICE_CREDENTIAL`                         |
| `allowBiometricWeak`            | Uses `BIOMETRIC_WEAK` instead of `BIOMETRIC_STRONG`                                 |

Net effect on Android:

- `allowDeviceCredential: false, allowBiometricWeak: false` → `BIOMETRIC_STRONG`
- `allowDeviceCredential: true,  allowBiometricWeak: false` → `BIOMETRIC_STRONG \| DEVICE_CREDENTIAL`
- `allowDeviceCredential: false, allowBiometricWeak: true`  → `BIOMETRIC_WEAK`
- `allowDeviceCredential: true,  allowBiometricWeak: true`  → `BIOMETRIC_WEAK \| DEVICE_CREDENTIAL`

### New API: `del` now accepts the same prompt options

`del` previously took only `key` + `withBiometrics`. It now also accepts
`biometricPrompt` so the auth UI can be customised on the Android side as well
(the iOS delete path is a no-op for biometrics — same as before).

### Bug fix: `ACCESSIBILITY` was being ignored on iOS

The public `ACCESSIBILITY` enum is a `string` enum (e.g.
`'AccessibleWhenUnlocked'`), but the iOS host function only handled
`isNumber()`. Calling `set({ accessibility: ACCESSIBILITY.WHEN_UNLOCKED })`
silently fell through to the default `kSecAttrAccessibleAfterFirstUnlock`.

Fix: a thin TypeScript wrapper normalises the string enum to the integer
codes iOS expects via a static lookup table, before forwarding to the native
side. iOS stays simple (`getAccessibilityValue(int)`), no breaking change for
consumers.

### iOS keychain prompt suppression when `withBiometrics: false`

`_delete` now sets `kSecUseAuthenticationUI: kSecUseAuthenticationUIFail` when
called without biometrics. Without this, deleting a value that was previously
written with `withBiometrics: true` would trigger the Face ID / passcode
prompt on the delete path even when the caller explicitly opted out.

## Backward compatibility

- `ACCESSIBILITY` enum values are unchanged (still strings).
- All new params are optional.
- `del` accepts the new `biometricPrompt` but ignores it on iOS (same as before — iOS delete never prompted).
- No native API was removed.

## Testing

- Example test suite was extended with:
  - accessibility for `WHEN_UNLOCKED`, `WHEN_PASSCODE_SET_THIS_DEVICE_ONLY`, `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`
  - biometricPrompt with defaults / `allowDeviceCredential` true & false / `allowBiometricWeak` true & false / both-true combo
  - explicit "no `biometricPrompt`" case validating the default prompt
  - gated by a local `RUN_BIOMETRIC_TESTS` flag — set to `true` on simulators/emulators where biometrics are not enrolled, `false` on physical devices where the Face ID / passcode prompt would otherwise block the suite

## Notes for the maintainer

- The previous iOS code was using `kSecAccessControlUserPresence` (allow
  biometrics OR passcode unconditionally). I narrowed this to
  `kSecAccessControlBiometryCurrentSet` by default and only add
  `kSecAccessControlDevicePasscode` when `allowDeviceCredential: true`. If
  you want to keep the previous "biometric OR passcode, always" behaviour
  as the default, change `allowDeviceCredential` default to `true` in
  `extractBiometricPromptArgs` (iOS) and `buildAuthenticators` (Android).
- The `run_once` warning in `cpp-adapter.cpp:35` is pre-existing and not
  introduced by this PR.
